### PR TITLE
[Feature] #44 - 주간 팀원 회고 상황 조회 API를 연결했습니다.

### DIFF
--- a/Puzzling/Puzzling.xcodeproj/project.pbxproj
+++ b/Puzzling/Puzzling.xcodeproj/project.pbxproj
@@ -66,6 +66,9 @@
 		03FFD2CC2A5B175C00A3B70D /* SFProType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FFD2CB2A5B175C00A3B70D /* SFProType.swift */; };
 		03FFD2CE2A5B1A8B00A3B70D /* AppleSDGothicNeoType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FFD2CD2A5B1A8B00A3B70D /* AppleSDGothicNeoType.swift */; };
 		03FFD2D92A5D968200A3B70D /* CreateProjectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FFD2D82A5D968200A3B70D /* CreateProjectViewController.swift */; };
+		0935C7FF2A6664CA00790A1B /* TeamMemberModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0935C7FE2A6664CA00790A1B /* TeamMemberModel.swift */; };
+		0935C8012A66727200790A1B /* ProjectTeamService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0935C8002A66727200790A1B /* ProjectTeamService.swift */; };
+		0935C8032A66854800790A1B /* ProjectTeamResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0935C8022A66854800790A1B /* ProjectTeamResponse.swift */; };
 		096755C62A5E970500A1E691 /* MyProjectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096755C52A5E970500A1E691 /* MyProjectViewController.swift */; };
 		096755CB2A5E9AF500A1E691 /* MyProjectTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096755CA2A5E9AF500A1E691 /* MyProjectTableViewCell.swift */; };
 		096755E62A60700E00A1E691 /* MyProjectTableHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096755E52A60700E00A1E691 /* MyProjectTableHeaderView.swift */; };
@@ -172,6 +175,9 @@
 		03FFD2D02A5B21D600A3B70D /* AppleSDGothicNeoH.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = AppleSDGothicNeoH.ttf; sourceTree = "<group>"; };
 		03FFD2D22A5B250800A3B70D /* Color.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Color.xcassets; sourceTree = "<group>"; };
 		03FFD2D82A5D968200A3B70D /* CreateProjectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateProjectViewController.swift; sourceTree = "<group>"; };
+		0935C7FE2A6664CA00790A1B /* TeamMemberModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamMemberModel.swift; sourceTree = "<group>"; };
+		0935C8002A66727200790A1B /* ProjectTeamService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectTeamService.swift; sourceTree = "<group>"; };
+		0935C8022A66854800790A1B /* ProjectTeamResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectTeamResponse.swift; sourceTree = "<group>"; };
 		096755BA2A5C61BE00A1E691 /* TeamMemberTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamMemberTableViewCell.swift; sourceTree = "<group>"; };
 		096755BE2A5D9E1A00A1E691 /* TeamMemberCustomHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamMemberCustomHeaderView.swift; sourceTree = "<group>"; };
 		096755C52A5E970500A1E691 /* MyProjectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyProjectViewController.swift; sourceTree = "<group>"; };
@@ -348,6 +354,7 @@
 		03E6D1FA2A5325A200F4453C /* DTO */ = {
 			isa = PBXGroup;
 			children = (
+				0935C7F62A65FCFC00790A1B /* Team */,
 				03E6D2042A5326D400F4453C /* DTO.swift */,
 				588AA0722A5ECDE70017CB1E /* IndivisualDashboardModel.swift */,
 				588AA0742A5ECDF10017CB1E /* TeamDashboardModel.swift */,
@@ -365,6 +372,7 @@
 				03E6D1FF2A5325F100F4453C /* Model.swift */,
 				03ADF3912A5E9534002CEDDC /* ProjectCycleModel.swift */,
 				0351AB3D2A619F04006B0F4C /* textFieldNotificationModel.swift */,
+				0935C7FE2A6664CA00790A1B /* TeamMemberModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -382,6 +390,7 @@
 			isa = PBXGroup;
 			children = (
 				03E6D2062A5326DD00F4453C /* APIService.swift */,
+				0935C8002A66727200790A1B /* ProjectTeamService.swift */,
 			);
 			path = APIService;
 			sourceTree = "<group>";
@@ -582,6 +591,14 @@
 				0351AB412A6323A8006B0F4C /* CustomAlertView.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		0935C7F62A65FCFC00790A1B /* Team */ = {
+			isa = PBXGroup;
+			children = (
+				0935C8022A66854800790A1B /* ProjectTeamResponse.swift */,
+			);
+			path = Team;
 			sourceTree = "<group>";
 		};
 		096755C22A5E96DC00A1E691 /* MyProject */ = {
@@ -905,6 +922,7 @@
 				03FFD2D92A5D968200A3B70D /* CreateProjectViewController.swift in Sources */,
 				03E6D1E92A53219600F4453C /* HomeViewController.swift in Sources */,
 				03E6D2402A532C2500F4453C /* Color.swift in Sources */,
+				0935C7FF2A6664CA00790A1B /* TeamMemberModel.swift in Sources */,
 				03E6D2662A53333500F4453C /* UIView+.swift in Sources */,
 				588AA0732A5ECDE70017CB1E /* IndivisualDashboardModel.swift in Sources */,
 				583117AA2A5BE2D90099B517 /* HomeSegmentedView.swift in Sources */,
@@ -926,6 +944,7 @@
 				583117A12A5B71920099B517 /* TeamDashboardViewController.swift in Sources */,
 				58EDAF952A5DDA04004EF5D3 /* IndivisualCardButtonView.swift in Sources */,
 				03E6D23C2A532BC600F4453C /* CustomClass.swift in Sources */,
+				0935C8032A66854800790A1B /* ProjectTeamResponse.swift in Sources */,
 				03E6D2702A53338200F4453C /* String+.swift in Sources */,
 				255026DF2A656D8100531543 /* OnBoardingViewController.swift in Sources */,
 				255026E52A657FB000531543 /* EnterProjectView.swift in Sources */,
@@ -937,6 +956,7 @@
 				03E6D2282A532AB900F4453C /* BaseViewController.swift in Sources */,
 				096755EA2A60710100A1E691 /* MyProjectDataModel.swift in Sources */,
 				9B1CA9782A62ADFD00CB81AC /* ReviewDetailEmptyView.swift in Sources */,
+				0935C8012A66727200790A1B /* ProjectTeamService.swift in Sources */,
 				0967560F2A61E73700A1E691 /* ReviewDetailView.swift in Sources */,
 				096755CB2A5E9AF500A1E691 /* MyProjectTableViewCell.swift in Sources */,
 				03E6D25A2A5331ED00F4453C /* APIConst.swift in Sources */,

--- a/Puzzling/Puzzling.xcodeproj/project.pbxproj
+++ b/Puzzling/Puzzling.xcodeproj/project.pbxproj
@@ -1147,7 +1147,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = Puzzling.ios;
+				PRODUCT_BUNDLE_IDENTIFIER = puzzling.i;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1181,7 +1181,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = Puzzling.ios;
+				PRODUCT_BUNDLE_IDENTIFIER = puzzling.i;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/Puzzling/Puzzling.xcodeproj/project.pbxproj
+++ b/Puzzling/Puzzling.xcodeproj/project.pbxproj
@@ -88,13 +88,9 @@
 		09C3AD5C2A65717500CDE00F /* TeamMemberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C3AD5B2A65717500CDE00F /* TeamMemberView.swift */; };
 		09C3AD5E2A65719100CDE00F /* TeamMemberViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C3AD5D2A65719100CDE00F /* TeamMemberViewController.swift */; };
 		251C00D52A5D205300F6838C /* CustomRadioButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 251C00D42A5D205300F6838C /* CustomRadioButton.swift */; };
-		251C00D72A5D309300F6838C /* BottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 251C00D62A5D309300F6838C /* BottomSheetViewController.swift */; };
-		251C00DD2A5F114800F6838C /* FiveFView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 251C00DC2A5F114800F6838C /* FiveFView.swift */; };
-		251C00E92A60343900F6838C /* testViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 251C00E82A60343900F6838C /* testViewController.swift */; };
 		255026DF2A656D8100531543 /* OnBoardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255026DE2A656D8100531543 /* OnBoardingViewController.swift */; };
 		255026E32A656EF100531543 /* OnBoardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255026E22A656EF100531543 /* OnBoardingView.swift */; };
 		255026E52A657FB000531543 /* EnterProjectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255026E42A657FB000531543 /* EnterProjectView.swift */; };
-		25F972642A61A839001CE10C /* CustomAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25F972632A61A839001CE10C /* CustomAlert.swift */; };
 		583117A12A5B71920099B517 /* TeamDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583117A02A5B71920099B517 /* TeamDashboardViewController.swift */; };
 		583117A32A5B71A00099B517 /* IndivisualDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583117A22A5B71A00099B517 /* IndivisualDashboardViewController.swift */; };
 		583117A82A5BE1490099B517 /* HomeTitleBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583117A72A5BE1490099B517 /* HomeTitleBarView.swift */; };
@@ -405,7 +401,6 @@
 			isa = PBXGroup;
 			children = (
 				255026DB2A656D1500531543 /* OnBoarding */,
-				251C00C52A5BE57C00F6838C /* CreateRetrospect */,
 				096756072A61DB3800A1E691 /* ReviewDetail */,
 				096755EC2A6078AD00A1E691 /* TeamMember */,
 				096755C22A5E96DC00A1E691 /* MyProject */,
@@ -1132,7 +1127,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = Puzzling;
+				PRODUCT_BUNDLE_IDENTIFIER = Puzzling.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1166,7 +1161,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = Puzzling;
+				PRODUCT_BUNDLE_IDENTIFIER = Puzzling.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/Puzzling/Puzzling.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Puzzling/Puzzling.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,95 @@
+{
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "bc268c28fb170f494de9e9927c371b8342979ece",
+        "version" : "5.7.1"
+      }
+    },
+    {
+      "identity" : "fscalendar",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/WenchaoD/FSCalendar",
+      "state" : {
+        "revision" : "0fbdec5172fccb90f707472eeaea4ffe095278f6",
+        "version" : "2.8.4"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "revision" : "d788f9a5a888f16253b9c3d9f3bd794835708c3f",
+        "version" : "2.15.0"
+      }
+    },
+    {
+      "identity" : "moya",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Moya/Moya",
+      "state" : {
+        "revision" : "c263811c1f3dbf002be9bd83107f7cdc38992b26",
+        "version" : "15.0.3"
+      }
+    },
+    {
+      "identity" : "reactiveswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveCocoa/ReactiveSwift.git",
+      "state" : {
+        "revision" : "c43bae3dac73fdd3cb906bd5a1914686ca71ed3c",
+        "version" : "6.7.0"
+      }
+    },
+    {
+      "identity" : "realm-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/realm-core.git",
+      "state" : {
+        "revision" : "f1434caadda443b4ed2261b91ea4f43ab1ee2aa5",
+        "version" : "13.15.1"
+      }
+    },
+    {
+      "identity" : "realm-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/realm-swift",
+      "state" : {
+        "branch" : "master",
+        "revision" : "5ed2c8ece79e63056641bd517435aaf81563f887"
+      }
+    },
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift.git",
+      "state" : {
+        "revision" : "9dcaa4b333db437b0fbfaf453fad29069044a8b4",
+        "version" : "6.6.0"
+      }
+    },
+    {
+      "identity" : "snapkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SnapKit/SnapKit",
+      "state" : {
+        "revision" : "f222cbdf325885926566172f6f5f06af95473158",
+        "version" : "5.6.0"
+      }
+    },
+    {
+      "identity" : "then",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/devxoul/Then",
+      "state" : {
+        "revision" : "d41ef523faef0f911369f79c0b96815d9dbb6d7a",
+        "version" : "3.0.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Puzzling/Puzzling/Application/SceneDelegate.swift
+++ b/Puzzling/Puzzling/Application/SceneDelegate.swift
@@ -23,7 +23,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             let window = UIWindow(windowScene: windowScene)
             window.overrideUserInterfaceStyle = UIUserInterfaceStyle.light
 
-            let vc = MyProjectViewController()
+            let vc = TeamMemberViewController()
             let rootVC = UINavigationController(rootViewController: vc)
             window.rootViewController = rootVC
             window.makeKeyAndVisible()

--- a/Puzzling/Puzzling/Data/DTO/Team/ProjectTeamResponse.swift
+++ b/Puzzling/Puzzling/Data/DTO/Team/ProjectTeamResponse.swift
@@ -1,0 +1,31 @@
+//
+//  ProjectTeamResponse.swift
+//  Puzzling
+//
+//  Created by Minjoo Kim on 2023/07/18.
+//
+
+import Foundation
+
+protocol TeamResponseProtocol {}
+
+struct ReviewWriters: Codable {
+    let memberNickname, memberRole: String
+}
+
+struct NonReviewWriters: Codable {
+    let memberNickname, memberRole: String
+}
+
+struct ProjectTeamResponse: Codable, TeamResponseProtocol {
+    let reviewDay, reviewDate: String
+    let reviewWriters: [ReviewWriters]?
+    let nonReviewWriters: [NonReviewWriters]?
+    
+    func convertToTeamMemberModel() -> TeamMemberModel {
+        return TeamMemberModel(reviewDay: reviewDay, reviewDate: reviewDate, reviewWriters: reviewWriters, nonReviewWriters: nonReviewWriters)
+    }
+}
+
+
+

--- a/Puzzling/Puzzling/Data/DTO/TeamMemberDataModel.swift
+++ b/Puzzling/Puzzling/Data/DTO/TeamMemberDataModel.swift
@@ -27,12 +27,32 @@ extension TeamMemberDataModel {
         return [TeamMemberDataModel(reviewDay: "월요일",
                                         reviewDate: "2023-07-10",
                                         reviewWriters:
-//                                        nil,
                                         [ReviewWriters(memberNickname: "닉네임은닉네임최대10자보이게할게요", memberRole: "역할도최대10글자일걸요ㅋㅋㅋ"),
                                                         ReviewWriters(memberNickname: "박솝트", memberRole: "iOS"),
                                                         ReviewWriters(memberNickname: "박솝트", memberRole: "iOS")],
-//                                        nonReviewWriters: nil)
-                                        nonReviewWriters: [NonReviewWriters(memberNickname: "나지롱", memberRole: "Server")])
+                                        nonReviewWriters: [NonReviewWriters(memberNickname: "나지롱", memberRole: "Server")]),
+                TeamMemberDataModel(reviewDay: "월요일",
+                                                reviewDate: "2023-07-12",
+                                                reviewWriters: nil,
+                                                nonReviewWriters: [NonReviewWriters(memberNickname: "나지롱", memberRole: "Server")]),
+                TeamMemberDataModel(reviewDay: "월요일",
+                                                reviewDate: "2023-07-14",
+                                                reviewWriters:
+        //                                        nil,
+                                                [ReviewWriters(memberNickname: "닉네임은닉네임최대10자보이게할게요", memberRole: "역할도최대10글자일걸요ㅋㅋㅋ"),
+                                                                ReviewWriters(memberNickname: "zzzzz", memberRole: "iOS"),
+                                                                ReviewWriters(memberNickname: "박솝트", memberRole: "iOS")],
+        //                                        nonReviewWriters: nil)
+                                                nonReviewWriters: [NonReviewWriters(memberNickname: "나지롱", memberRole: "Server")]),
+                TeamMemberDataModel(reviewDay: "화요일",
+                                                reviewDate: "2023-07-18",
+                                                reviewWriters:
+        //                                        nil,
+                                                [ReviewWriters(memberNickname: "닉네임은닉네임최대10자보이게할게요", memberRole: "역할도최대10글자일걸요ㅋㅋㅋ"),
+                                                                ReviewWriters(memberNickname: "zzzzz", memberRole: "iOS"),
+                                                                ReviewWriters(memberNickname: "박솝트", memberRole: "iOS")],
+        //                                        nonReviewWriters: nil)
+                                                nonReviewWriters: [NonReviewWriters(memberNickname: "나지롱", memberRole: "Server")])
                ]
     }
 }

--- a/Puzzling/Puzzling/Data/DTO/TeamMemberDataModel.swift
+++ b/Puzzling/Puzzling/Data/DTO/TeamMemberDataModel.swift
@@ -4,55 +4,55 @@
 //
 //  Created by Minjoo Kim on 2023/07/14.
 //
-
-struct TeamMemberDataModel {
-    let reviewDay: String
-    let reviewDate: String
-    let reviewWriters: [ReviewWriters]?
-    let nonReviewWriters: [NonReviewWriters]?
-}
-
-struct ReviewWriters {
-    let memberNickname: String
-    let memberRole: String
-}
-
-struct NonReviewWriters {
-    let memberNickname: String
-    let memberRole: String
-}
-
-extension TeamMemberDataModel {
-    static func dummy() -> [TeamMemberDataModel] {
-        return [TeamMemberDataModel(reviewDay: "월요일",
-                                        reviewDate: "2023-07-10",
-                                        reviewWriters:
-                                        [ReviewWriters(memberNickname: "닉네임은닉네임최대10자보이게할게요", memberRole: "역할도최대10글자일걸요ㅋㅋㅋ"),
-                                                        ReviewWriters(memberNickname: "박솝트", memberRole: "iOS"),
-                                                        ReviewWriters(memberNickname: "박솝트", memberRole: "iOS")],
-                                        nonReviewWriters: [NonReviewWriters(memberNickname: "나지롱", memberRole: "Server")]),
-                TeamMemberDataModel(reviewDay: "월요일",
-                                                reviewDate: "2023-07-12",
-                                                reviewWriters: nil,
-                                                nonReviewWriters: [NonReviewWriters(memberNickname: "나지롱", memberRole: "Server")]),
-                TeamMemberDataModel(reviewDay: "월요일",
-                                                reviewDate: "2023-07-14",
-                                                reviewWriters:
-        //                                        nil,
-                                                [ReviewWriters(memberNickname: "닉네임은닉네임최대10자보이게할게요", memberRole: "역할도최대10글자일걸요ㅋㅋㅋ"),
-                                                                ReviewWriters(memberNickname: "zzzzz", memberRole: "iOS"),
-                                                                ReviewWriters(memberNickname: "박솝트", memberRole: "iOS")],
-        //                                        nonReviewWriters: nil)
-                                                nonReviewWriters: [NonReviewWriters(memberNickname: "나지롱", memberRole: "Server")]),
-                TeamMemberDataModel(reviewDay: "화요일",
-                                                reviewDate: "2023-07-18",
-                                                reviewWriters:
-        //                                        nil,
-                                                [ReviewWriters(memberNickname: "닉네임은닉네임최대10자보이게할게요", memberRole: "역할도최대10글자일걸요ㅋㅋㅋ"),
-                                                                ReviewWriters(memberNickname: "zzzzz", memberRole: "iOS"),
-                                                                ReviewWriters(memberNickname: "박솝트", memberRole: "iOS")],
-        //                                        nonReviewWriters: nil)
-                                                nonReviewWriters: [NonReviewWriters(memberNickname: "나지롱", memberRole: "Server")])
-               ]
-    }
-}
+//
+//struct TeamMemberDataModel {
+//    let reviewDay: String
+//    let reviewDate: String
+//    let reviewWriters: [ReviewWriters]?
+//    let nonReviewWriters: [NonReviewWriters]?
+//}
+//
+//struct ReviewWriters {
+//    let memberNickname: String
+//    let memberRole: String
+//}
+//
+//struct NonReviewWriters {
+//    let memberNickname: String
+//    let memberRole: String
+//}
+//
+//extension TeamMemberDataModel {
+//    static func dummy() -> [TeamMemberDataModel] {
+//        return [TeamMemberDataModel(reviewDay: "월요일",
+//                                        reviewDate: "2023-07-10",
+//                                        reviewWriters:
+//                                        [ReviewWriters(memberNickname: "닉네임은닉네임최대10자보이게할게요", memberRole: "역할도최대10글자일걸요ㅋㅋㅋ"),
+//                                                        ReviewWriters(memberNickname: "박솝트", memberRole: "iOS"),
+//                                                        ReviewWriters(memberNickname: "박솝트", memberRole: "iOS")],
+//                                        nonReviewWriters: [NonReviewWriters(memberNickname: "나지롱", memberRole: "Server")]),
+//                TeamMemberDataModel(reviewDay: "월요일",
+//                                                reviewDate: "2023-07-12",
+//                                                reviewWriters: nil,
+//                                                nonReviewWriters: [NonReviewWriters(memberNickname: "나지롱", memberRole: "Server")]),
+//                TeamMemberDataModel(reviewDay: "월요일",
+//                                                reviewDate: "2023-07-14",
+//                                                reviewWriters:
+//        //                                        nil,
+//                                                [ReviewWriters(memberNickname: "닉네임은닉네임최대10자보이게할게요", memberRole: "역할도최대10글자일걸요ㅋㅋㅋ"),
+//                                                                ReviewWriters(memberNickname: "zzzzz", memberRole: "iOS"),
+//                                                                ReviewWriters(memberNickname: "박솝트", memberRole: "iOS")],
+//        //                                        nonReviewWriters: nil)
+//                                                nonReviewWriters: [NonReviewWriters(memberNickname: "나지롱", memberRole: "Server")]),
+//                TeamMemberDataModel(reviewDay: "화요일",
+//                                                reviewDate: "2023-07-18",
+//                                                reviewWriters:
+//        //                                        nil,
+//                                                [ReviewWriters(memberNickname: "닉네임은닉네임최대10자보이게할게요", memberRole: "역할도최대10글자일걸요ㅋㅋㅋ"),
+//                                                                ReviewWriters(memberNickname: "zzzzz", memberRole: "iOS"),
+//                                                                ReviewWriters(memberNickname: "박솝트", memberRole: "iOS")],
+//        //                                        nonReviewWriters: nil)
+//                                                nonReviewWriters: [NonReviewWriters(memberNickname: "나지롱", memberRole: "Server")])
+//               ]
+//    }
+//}

--- a/Puzzling/Puzzling/Data/Model/TeamMemberModel.swift
+++ b/Puzzling/Puzzling/Data/Model/TeamMemberModel.swift
@@ -1,0 +1,25 @@
+//
+//  TeamMemberModel.swift
+//  Puzzling
+//
+//  Created by Minjoo Kim on 2023/07/18.
+//
+
+import Foundation
+
+struct TeamMemberModel: Codable, TeamResponseProtocol {
+    let reviewDay: String
+    let reviewDate: String
+    let reviewWriters: [ReviewWriters]?
+    let nonReviewWriters: [NonReviewWriters]?
+}
+//
+//struct ReviewWriters {
+//    let memberNickname: String
+//    let memberRole: String
+//}
+//
+//struct NonReviewWriters {
+//    let memberNickname: String
+//    let memberRole: String
+//}

--- a/Puzzling/Puzzling/Network/APIService/ProjectTeamService.swift
+++ b/Puzzling/Puzzling/Network/APIService/ProjectTeamService.swift
@@ -1,0 +1,51 @@
+//
+//  ProjectTeamService.swift
+//  Puzzling
+//
+//  Created by Minjoo Kim on 2023/07/18.
+//
+
+import Foundation
+import Moya
+
+enum ProjectTeamService {
+    case teamMember(projectId: String, startDate: String, endDate: String)
+}
+
+extension ProjectTeamService: TargetType {
+    var baseURL: URL {
+        return URL(string: URLConst.baseURL)!
+    }
+
+    var path: String {
+        switch self {
+        case .teamMember(let projectId, _, _):
+            return URLConst.getProjectTeamReviewURL.replacingOccurrences(of: "{projectId}", with: "\(projectId)")
+        }
+    }
+
+    var method: Moya.Method {
+        switch self {
+        case .teamMember:
+            return .get
+        }
+    }
+
+    var task: Moya.Task {
+        switch self {
+        case .teamMember(_, let startDate, let endDate):
+            let param: [String: Any] = [
+                URLConst.startDate: startDate,
+                URLConst.endDate: endDate
+            ]
+            return .requestParameters(parameters: param, encoding: URLEncoding.queryString)
+        }
+    }
+
+    var headers: [String : String]? {
+        switch self {
+        case .teamMember:
+            return APIConstants.headerWithAuthorization
+        }
+    }
+}

--- a/Puzzling/Puzzling/Network/Foundation/APIConst.swift
+++ b/Puzzling/Puzzling/Network/Foundation/APIConst.swift
@@ -21,6 +21,7 @@ enum APIConstants {
     static let applicationJSON = "application/json"
     static var deviceToken: String = ""
     static var jwtToken: String = ""
+    static var accessToken: String = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2ODk2MTIzODEsImV4cCI6MTY4OTk3MjM4MSwibWVtYmVySWQiOjF9.Ktl_IFV0hKtOG4qgyx9erGfBP-w80CzhslxZWgUFg3s"
     
     //MARK: - Header
     
@@ -38,7 +39,7 @@ enum APIConstants {
     static var headerWithAuthorization: [String: String] {
         [
             NetworkHeaderKey.contentType.rawValue: APIConstants.applicationJSON,
-            NetworkHeaderKey.authorization.rawValue: APIConstants.jwtToken
+            NetworkHeaderKey.authorization.rawValue: URLConst.bearer + APIConstants.accessToken
         ]
     }
 }

--- a/Puzzling/Puzzling/Network/Foundation/URLConst.swift
+++ b/Puzzling/Puzzling/Network/Foundation/URLConst.swift
@@ -57,4 +57,5 @@ public enum URLConst {
     static let endDate = "endDate"
     static let today = "today"
     static let invitationCode = "invitationCode"
+    static let bearer = "Bearer "
 }

--- a/Puzzling/Puzzling/Presentation/ReviewDetail/ViewController/ReviewDetailViewController.swift
+++ b/Puzzling/Puzzling/Presentation/ReviewDetail/ViewController/ReviewDetailViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import SnapKit
 import Then
+import Moya
 
 extension ReviewDetailViewController {
     @frozen
@@ -35,8 +36,6 @@ final class ReviewDetailViewController: UIViewController {
     }
     
     private var reviewDetailView = ReviewDetailView()
-    
-    private let teamMemberData = TeamMemberDataModel.dummy()
     
     // MARK: - Lifecycle
     

--- a/Puzzling/Puzzling/Presentation/TeamMember/View/TeamMemberTableViewCell.swift
+++ b/Puzzling/Puzzling/Presentation/TeamMember/View/TeamMemberTableViewCell.swift
@@ -61,7 +61,6 @@ final class TeamMemberTableViewCell: UITableViewCell {
             $0.width.equalTo(122)
             $0.trailing.equalToSuperview().inset(32)
             $0.top.bottom.equalToSuperview()
-            $0.height.equalTo(30)
         }
         
         divisionLabel.snp.makeConstraints {

--- a/Puzzling/Puzzling/Presentation/TeamMember/View/TeamMemberView.swift
+++ b/Puzzling/Puzzling/Presentation/TeamMember/View/TeamMemberView.swift
@@ -14,6 +14,7 @@ import Moya
 
 final class TeamMemberCalendarView: UIView {
     
+    private var selectedDate: String = ""
     private lazy var calendarView = FSCalendar(frame: .zero)
     private var calendarViewHeight = NSLayoutConstraint()
     private lazy var headerLabel = UILabel()
@@ -50,7 +51,6 @@ final class TeamMemberCalendarView: UIView {
 extension TeamMemberCalendarView {
     private func setUI() {
         calendarView.do {
-            $0.select(Date())
             
             $0.locale = Locale(identifier: "ko_KR")
             $0.scope = .week
@@ -73,6 +73,7 @@ extension TeamMemberCalendarView {
             
             $0.scrollEnabled = true
             $0.scrollDirection = .horizontal
+            $0.today = nil
         }
         
         headerLabel.do {
@@ -120,6 +121,7 @@ extension TeamMemberCalendarView {
     
     private func setNotificationCenter() {
         NotificationCenter.default.addObserver(self, selector: #selector(getListNotification(_:)), name: Notification.Name("listNotification"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(getDateNotification(_:)), name: Notification.Name("dateNotification"), object: nil)
     }
 }
 
@@ -128,6 +130,14 @@ extension TeamMemberCalendarView {
     private func getListNotification(_ notification: Notification) {
         let listNotification = notification.userInfo?["userInfo"]
         teamMemberList = listNotification as! [TeamMemberModel]
+        calendarView.reloadData()
+    }
+    
+    @objc
+    private func getDateNotification(_ notification: Notification) {
+        let dateNotification = notification.userInfo?["userInfo"]
+        selectedDate = dateNotification as! String
+        calendarView.select(dateFormatter.date(from: selectedDate))
     }
 }
 
@@ -182,11 +192,6 @@ extension TeamMemberCalendarView: FSCalendarDelegate, FSCalendarDataSource, FSCa
 }
 
 extension TeamMemberCalendarView {
-    func setDataBind() {
-        calendarView.setScope(.month, animated: true)
-        headerDateFormatter.dateFormat = "YYYY년 M월"
-        headerLabel.text = headerDateFormatter.string(from: calendarView.currentPage)
-    }
     
     func getCalendarViewHeight() -> CGFloat{
         print(self.calendarViewHeight.constant , #function)

--- a/Puzzling/Puzzling/Presentation/TeamMember/View/TeamMemberView.swift
+++ b/Puzzling/Puzzling/Presentation/TeamMember/View/TeamMemberView.swift
@@ -10,6 +10,7 @@ import UIKit
 import FSCalendar
 import SnapKit
 import Then
+import Moya
 
 final class TeamMemberCalendarView: UIView {
     
@@ -23,9 +24,8 @@ final class TeamMemberCalendarView: UIView {
         $0.locale = Locale(identifier: "ko_kr")
         $0.timeZone = TimeZone(identifier: "KST")
     }
-    
-    private let teamMemberData = TeamMemberDataModel.dummy()
-    
+    private var teamMemberList: [TeamMemberModel] = [TeamMemberModel(reviewDay: "", reviewDate: "", reviewWriters: nil, nonReviewWriters: nil)]
+
     private let headerDateFormatter = DateFormatter().then {
         $0.dateFormat = "YYYY년 M월"
         $0.locale = Locale(identifier: "ko_kr")
@@ -39,6 +39,7 @@ final class TeamMemberCalendarView: UIView {
         setLayout()
         setDelegate()
         calendarViewHeight.constant = 350
+        setNotificationCenter()
     }
     
     required init?(coder: NSCoder) {
@@ -117,6 +118,20 @@ extension TeamMemberCalendarView {
             userInfo: ["userInfo": userInfo]
         )
     }
+    
+    private func setNotificationCenter() {
+        NotificationCenter.default.addObserver(self, selector: #selector(getListNotification(_:)), name: Notification.Name("listNotification"), object: nil)
+        
+    }
+}
+
+extension TeamMemberCalendarView {
+    @objc
+    private func getListNotification(_ notification: Notification) {
+        let listNotification = notification.userInfo?["userInfo"]
+        teamMemberList = listNotification as! [TeamMemberModel]
+//        teamMemberTableView.reloadData()
+    }
 }
 
 extension TeamMemberCalendarView: FSCalendarDelegate, FSCalendarDataSource, FSCalendarDelegateAppearance {
@@ -132,7 +147,7 @@ extension TeamMemberCalendarView: FSCalendarDelegate, FSCalendarDataSource, FSCa
     
     func calendar(_ calendar: FSCalendar, shouldSelect date: Date, at monthPosition: FSCalendarMonthPosition) -> Bool {
         var boolData: Bool = false
-        teamMemberData.forEach {
+        teamMemberList.forEach {
             if(date == dateFormatter.date(from: $0.reviewDate)) {
                 boolData = true
             }
@@ -142,7 +157,7 @@ extension TeamMemberCalendarView: FSCalendarDelegate, FSCalendarDataSource, FSCa
     
     func calendar(_ calendar: FSCalendar, appearance: FSCalendarAppearance, fillDefaultColorFor date: Date) -> UIColor? {
         var colorData: UIColor = .clear
-        teamMemberData.forEach {
+        teamMemberList.forEach {
             if(date == dateFormatter.date(from: $0.reviewDate) && $0.reviewWriters != nil) {
                 colorData = .blue100
             }
@@ -152,7 +167,7 @@ extension TeamMemberCalendarView: FSCalendarDelegate, FSCalendarDataSource, FSCa
     
     func calendar(_ calendar: FSCalendar, appearance: FSCalendarAppearance, titleDefaultColorFor date: Date) -> UIColor? {
         var colorData: UIColor = .gray400
-        teamMemberData.forEach {
+        teamMemberList.forEach {
             if(date == dateFormatter.date(from: $0.reviewDate)) {
                 colorData = .black000
             }

--- a/Puzzling/Puzzling/Presentation/TeamMember/View/TeamMemberView.swift
+++ b/Puzzling/Puzzling/Presentation/TeamMember/View/TeamMemberView.swift
@@ -75,7 +75,6 @@ extension TeamMemberCalendarView {
             $0.scrollDirection = .horizontal
         }
         
-        
         headerLabel.do {
             $0.font = .fontGuide(.heading2_kor)
             $0.textColor = .black000
@@ -112,6 +111,7 @@ extension TeamMemberCalendarView {
     
     private func sendDateNotification(string: String) {
         let userInfo = string
+        print(userInfo, "이건 노티입니당")
         NotificationCenter.default.post(
             name: Notification.Name("dateNotification"),
             object: nil,
@@ -121,7 +121,6 @@ extension TeamMemberCalendarView {
     
     private func setNotificationCenter() {
         NotificationCenter.default.addObserver(self, selector: #selector(getListNotification(_:)), name: Notification.Name("listNotification"), object: nil)
-        
     }
 }
 
@@ -130,7 +129,6 @@ extension TeamMemberCalendarView {
     private func getListNotification(_ notification: Notification) {
         let listNotification = notification.userInfo?["userInfo"]
         teamMemberList = listNotification as! [TeamMemberModel]
-//        teamMemberTableView.reloadData()
     }
 }
 
@@ -180,14 +178,7 @@ extension TeamMemberCalendarView: FSCalendarDelegate, FSCalendarDataSource, FSCa
     }
     
     func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
-//        sendDateBoolNotification(bool: true)
         sendDateNotification(string: dateFormatter.string(from: date))
-//        teamMemberData.forEach {
-//            let modelDate = dateFormatter.date(from: $0.reviewDate)
-//            if(date == modelDate && $0.reviewWriters == nil) {
-//                sendDateBoolNotification(bool: false)
-//            }
-//        }
     }
 }
 

--- a/Puzzling/Puzzling/Presentation/TeamMember/View/TeamMemberView.swift
+++ b/Puzzling/Puzzling/Presentation/TeamMember/View/TeamMemberView.swift
@@ -111,7 +111,6 @@ extension TeamMemberCalendarView {
     
     private func sendDateNotification(string: String) {
         let userInfo = string
-        print(userInfo, "이건 노티입니당")
         NotificationCenter.default.post(
             name: Notification.Name("dateNotification"),
             object: nil,

--- a/Puzzling/Puzzling/Presentation/TeamMember/ViewController/TeamMemberViewController.swift
+++ b/Puzzling/Puzzling/Presentation/TeamMember/ViewController/TeamMemberViewController.swift
@@ -26,23 +26,20 @@ final class TeamMemberViewController: UIViewController {
     
     private func findData(date: String) -> TeamMemberModel? {
         var data = TeamMemberModel(reviewDay: "", reviewDate: "", reviewWriters: nil, nonReviewWriters: nil)
-//        temMemberList?.forEach {
-//            if($0.reviewDate == date){
-//                data = $0
-//            }
-//        }
+        dataList.forEach {
+            if($0.reviewDate == date){
+                data = $0
+            }
+        }
         return data
     }
     
     private let teamMemberCalenderView = TeamMemberCalendarView()
     private let teamMemberTableView = UITableView(frame: .zero, style: .grouped)
     
-//    private let teamMemberData = TeamMemberDataModel.dummy()
-    
     private let projectTeamProvider = MoyaProvider<ProjectTeamService>(plugins:[NetworkLoggerPlugin()])
     private var teamMemberList: [TeamMemberModel] = []
     
-//        private var invitationCodeModel: InvitationCodeModel?
     // MARK: - Lifecycle
     
     override func viewDidLoad() {
@@ -52,7 +49,6 @@ final class TeamMemberViewController: UIViewController {
         setLayout()
         setRegister()
         setNotificationCenter()
-//        fetchTeamMember()
         fetchTeamMember()
     }
     
@@ -186,7 +182,6 @@ extension TeamMemberViewController {
         specificData = findData(date: selectedDate) ?? TeamMemberModel(reviewDay: "", reviewDate: "", reviewWriters: nil, nonReviewWriters: nil)
         teamMemberTableView.reloadData()
     }
-    
 }
 
 extension TeamMemberViewController: UITableViewDelegate {}
@@ -267,54 +262,24 @@ extension TeamMemberViewController {
             switch result {
             case .success(let result):
                 let status = result.statusCode
-                print(status, "😏😏😏😏😏")
+                print(status)
                 if status >= 200 && status < 300 {
                     do {
                         guard let data = try result.map(GeneralResponse<[ProjectTeamResponse]>.self).data else { return }
                         
-//                        let teamMemberCalendarView = TeamMemberCalendarView()
-//                        var dataList: [TeamMemberModel] = []
                         data.forEach {
                             self.dataList.append($0.convertToTeamMemberModel())
                         }
-                        print(self.dataList)
-//                        self.setNotificationCenter()
                         
                         self.sendDateNotification(model: self.dataList)
-//                        print(teamMemberCalendarView.teamMemberList)
-//                        self.teamMemberCalenderView.teamMemberList = data.
                         print("♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️")
                         
-//                        dataList.calendarView.reloadData()
                         
-//                        teamMemberView.modalPresentationStyle = .fullScreen
-                        
-//                        if let reviewDay = self.teamMemberList?.reviewDay {
-////                            createProfileVC.projectID = projectID
-//                            teamMemberCalendarView.reviewDay = reviewDay
-//                            print(reviewDay)
-//                        }
-//                        if let reviewDate = self.teamMemberList?.reviewDate {
-////                            createProfileVC.projectName = projectName
-//                            teamMemberCalendarView.reviewDate = reviewDate
-//                            print(reviewDate)
-//                        }
-//                        if let reviewWriters = self.teamMemberList?.reviewWriters{
-//                            teamMemberCalendarView.reviewWriters = reviewWriters
-//                            print(reviewWriters)
-//                        }
-//                        if let nonReviewWriters = self.teamMemberList?.nonReviewWriters{
-//                            teamMemberCalendarView.nonReviewWriters = nonReviewWriters
-//                            print(nonReviewWriters)
-//                        }
-//                        self.present(createProfileVC, animated: true)
                     } catch(let error) {
                         print(error.localizedDescription)
                     }
                 } else if status == 404 {
                     print("💭💭💭💭💭💭💭💭💭💭💭💭💭💭💭💭💭💭💭")
-//                    self.textFieldWarningNotification(type: .invitationCode)
-                    //                    self.inputCompletionButton.setState(.notAllow)
                 }
             case .failure(let error):
                 print(error.localizedDescription)

--- a/Puzzling/Puzzling/Presentation/TeamMember/ViewController/TeamMemberViewController.swift
+++ b/Puzzling/Puzzling/Presentation/TeamMember/ViewController/TeamMemberViewController.swift
@@ -43,6 +43,7 @@ final class TeamMemberViewController: UIViewController {
         setUI()
         setLayout()
         setRegister()
+        setNotificationCenter()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -53,7 +54,6 @@ final class TeamMemberViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         setCalendarViewLayout()
-        setNotificationCenter()
     }
     
     deinit {

--- a/Puzzling/Puzzling/Presentation/TeamMember/ViewController/TeamMemberViewController.swift
+++ b/Puzzling/Puzzling/Presentation/TeamMember/ViewController/TeamMemberViewController.swift
@@ -16,12 +16,11 @@ final class TeamMemberViewController: UIViewController {
     
     private var index: Int = 0
     
-    private var selectedDate: String = ""
-    private var startDate: String = "2023-07-10"
-    private var endDate: String = "2023-07-25"
+    private var selectedDate: String = "2023-07-21"
+    private var startDate: String = "2023-04-01"
+    private var endDate: String = "2023-12-13"
     
     private var specificData = TeamMemberModel(reviewDay: "", reviewDate: "", reviewWriters: nil, nonReviewWriters: nil)
-//    private var dataList = []
     private var dataList: [TeamMemberModel] = []
     
     private func findData(date: String) -> TeamMemberModel? {
@@ -50,6 +49,7 @@ final class TeamMemberViewController: UIViewController {
         setRegister()
         setNotificationCenter()
         fetchTeamMember()
+        sendNotification(string: selectedDate)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -141,13 +141,21 @@ extension TeamMemberViewController {
     
     private func setNotificationCenter() {
         NotificationCenter.default.addObserver(self, selector: #selector(getDateNotification(_:)), name: Notification.Name("dateNotification"), object: nil)
-        
     }
     
     private func sendDateNotification(model: [TeamMemberModel]) {
         let userInfo = model
         NotificationCenter.default.post(
             name: Notification.Name("listNotification"),
+            object: nil,
+            userInfo: ["userInfo": userInfo]
+        )
+    }
+    
+    private func sendNotification(string: String) {
+        let userInfo = string
+        NotificationCenter.default.post(
+            name: Notification.Name("dateNotification"),
             object: nil,
             userInfo: ["userInfo": userInfo]
         )
@@ -168,11 +176,6 @@ extension TeamMemberViewController {
         view.window?.layer.add(transition, forKey: kCATransition)
         dismiss(animated: false)
         self.navigationController?.popViewController(animated: false)
-    }
-    
-    @objc
-    private func tapToggleButton() {
-        teamMemberCalenderView.setDataBind()
     }
     
     @objc
@@ -258,7 +261,7 @@ extension TeamMemberViewController {
     
     private func fetchTeamMember() {
         print(startDate, endDate)
-        projectTeamProvider.request(.teamMember(projectId: "2", startDate: startDate, endDate: endDate)) { result in
+        projectTeamProvider.request(.teamMember(projectId: "1", startDate: startDate, endDate: endDate)) { result in
             switch result {
             case .success(let result):
                 let status = result.statusCode
@@ -272,6 +275,8 @@ extension TeamMemberViewController {
                         }
                         
                         self.sendDateNotification(model: self.dataList)
+                        self.specificData = self.findData(date: self.selectedDate) ?? TeamMemberModel(reviewDay: "", reviewDate: "", reviewWriters: nil, nonReviewWriters: nil)
+                        self.teamMemberTableView.reloadData()
                         print("♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️")
                         
                         


### PR DESCRIPTION
## 💭 작업 배경
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
 - 주간 팀원 회고 상황 조회 API를 연결했습니다. 
 - 팀 대시보드에서 선택하는 날짜를 delegate 또는 NotificationCenter로 받아와야 합니다. 일단 NotificationCenter는 구현을 했고, 뷰컨끼리 연결할 때 추가로 작업하면 될 것 같습니다. 
 - 서버통신 시 프로젝트 시작 날짜를 startDate에 넣어야 하는데, 이를 받아오는 로직을 추가로 구현해야합니다. 현재는 임의의 날짜 값을 startDate에 넣어놨습니다. 

## 🌤️ PR POINT
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->
아자잦..

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| PNG | <img src = "https://github.com/Team-Puzzling/Puzzling_iOS/assets/89457040/94e46e4e-0e0e-458c-a19c-87c2a61dab68" width ="250">|

## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #44 

<!--
![IMG_1883](https://github.com/Team-Puzzling/Puzzling_iOS/assets/89457040/94e46e4e-0e0e-458c-a19c-87c2a61dab68) -->
