### PR TITLE
[Fix] #90 - 마이너한 버그 수정 및 데이터 로딩 인디케이터를 추가했습니다.

### DIFF
--- a/Puzzling/Puzzling/Presentation/ReviewDetail/View/ProjectCalendarView.swift
+++ b/Puzzling/Puzzling/Presentation/ReviewDetail/View/ProjectCalendarView.swift
@@ -28,8 +28,8 @@ final class ProjectCalendarView: UIView {
     // MARK: - Properties
     
     weak var delegate: reviewDateProtocol?
-    private var startDate: String = "2023-04-01"
-    private var endDate: String = "2023-12-13"
+    private var startDate: String = "2023-07-01"
+    private var endDate: String = "2023-08-15"
     private var selectedDate: String = "2023-07-14"
     private var specificData = ReviewDetailModel(reviewId: nil, reviewDay: "", reviewDate: "", reviewTemplateId: nil, contents: nil)
     private var dataList: [ReviewDetailModel] = []

--- a/Puzzling/Puzzling/Presentation/TeamMember/ViewController/TeamMemberViewController.swift
+++ b/Puzzling/Puzzling/Presentation/TeamMember/ViewController/TeamMemberViewController.swift
@@ -8,9 +8,9 @@
 import UIKit
 
 import FSCalendar
+import Moya
 import SnapKit
 import Then
-import Moya
 
 final class TeamMemberViewController: UIViewController {
     
@@ -30,6 +30,7 @@ final class TeamMemberViewController: UIViewController {
     private let teamMemberCalenderView = TeamMemberCalendarView()
     private let projectTeamProvider = MoyaProvider<ProjectTeamService>(plugins:[NetworkLoggerPlugin()])
     private var teamMemberList: [TeamMemberModel] = []
+    private lazy var loadingIndicatorView = UIActivityIndicatorView(style: .large)
     
     // MARK: - View Life Cycle
     
@@ -74,12 +75,17 @@ extension TeamMemberViewController {
             $0.sectionHeaderTopPadding = 0
             $0.sectionFooterHeight = 0
         }
+        
+        loadingIndicatorView.do {
+            $0.color = .blue300
+            $0.startAnimating()
+        }
     }
     
     // MARK: - Layout Helper
     
     private func setLayout() {
-        view.addSubviews(teamMemberCalenderView, teamMemberTableView)
+        view.addSubviews(teamMemberCalenderView, teamMemberTableView, loadingIndicatorView)
         
         teamMemberCalenderView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide)
@@ -91,6 +97,11 @@ extension TeamMemberViewController {
             $0.top.equalTo(teamMemberCalenderView.snp.bottom)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalToSuperview()
+        }
+        
+        loadingIndicatorView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.size.equalTo(90)
         }
     }
     
@@ -292,9 +303,9 @@ extension TeamMemberViewController {
                         self.sendDateNotification(model: self.dataList)
                         self.specificData = self.findData(date: self.selectedDate) ?? TeamMemberModel(reviewDay: "", reviewDate: "", reviewWriters: nil, nonReviewWriters: nil)
                         self.teamMemberTableView.reloadData()
-                        print("♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️♥️")
-                        
-                        
+                        self.loadingIndicatorView.stopAnimating()
+                        self.loadingIndicatorView.alpha = 0
+                        self.loadingIndicatorView.removeFromSuperview()
                     } catch(let error) {
                         print(error.localizedDescription)
                     }


### PR DESCRIPTION
## 🌤️ PR POINT
 - 마이너한 UI 버그를 수정했습니다.
 - 캘린더 뷰에서 데이터를 받아오는 기간을 적게 했습니다.

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| mp4 | <img src = "https://github.com/Team-Puzzling/Puzzling_iOS/assets/89404664/155c47df-5525-4eea-b270-ee3fc73d1a07" width ="250">|

## 🌈 관련 이슈
- #90 
